### PR TITLE
Patch pkg-config so we can #include <uuid.h> and #include <uuid/uuid.h>

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -8,6 +8,12 @@ share {
   plugin Extract => 'tar.gz';
   plugin 'Build::Autoconf';
 
+  patch [
+      # Patch pkg-config so we can #include <uuid.h> and #include <uuid/uuid.h>
+      '%{patch} -p0 < %{.install.patch}/uuid.pc.in.patch',
+  ];
+
+
   build [
     '%{configure}',
     '%{make}',

--- a/patch/uuid.pc.in.patch
+++ b/patch/uuid.pc.in.patch
@@ -1,0 +1,9 @@
+--- uuid.pc.in	2014-08-12 10:07:18.000000000 +0200
++++ uuid.pc.in	2020-05-08 15:13:40.515784809 +0200
+@@ -7,5 +7,5 @@
+ Description: Universally unique id library
+ Version: @LIBUUID_VERSION@
+ Requires:
+-Cflags: -I${includedir}/uuid
++Cflags: -I${includedir}/uuid -I${includedir}
+ Libs: -L${libdir} -luuid


### PR DESCRIPTION
Hello,

We discussed a lot this issue on IRC and it is reported as #4 

I propose this change to fix the libuuid pkg-config. 

See the pkg-config result after Alien::libuuid install : 

```
export set PKG_CONFIG_PATH=/usr/local/lib/x86_64-linux-gnu/perl/5.26.1/auto/share/dist/Alien-libuuid/lib/pkgconfig/
```

```
pkg-config --cflags uuid
-I/usr/local/lib/x86_64-linux-gnu/perl/5.26.1/auto/share/dist/Alien-libuuid/include/uuid -I/usr/local/lib/x86_64-linux-gnu/perl/5.26.1/auto/share/dist/Alien-libuuid/include
```

I tested also with my version of Alien::Gearman that use libuuid (and disabled the [cflags hack](https://github.com/thibaultduponchelle/Alien-Gearman/blob/master/Makefile.PL#L35)).

It will help also for [Alien::KentSrc](https://github.com/kiwiroy/alien-kentsrc/blob/lib-deps/alienfile#L30) (it is not the current main branch/repo but should be probably in the future I guess)

I hope it will be OK for you.

Best regards.

Thibault 